### PR TITLE
feat: change build name default

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 description: >
-    Easily build and test Unity projects. The project artifacts and test results are stored in CircleCI and can be opened in the Workflow dashboard.
-    Supports Linux x86_64.
+    Easily build and test Unity projects. The project artifacts and test results are stored in CircleCI and can be opened in the Workflow web app.
+    Supports Windows, Linux and macOS.
 
 display:
-  home_url: "https://game.ci/docs/"
+  home_url: "https://game.ci/docs/circleci/getting-started"
   source_url: "https://github.com/game-ci/unity-orb"

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -64,7 +64,7 @@ steps:
       condition: << parameters.compress >>
       steps:
         - store_artifacts:
-            path: << parameters.build-name >>-<< parameters.build-target >>.tar.gz
+            path: << parameters.build-target >>.tar.gz
   - unless:
       condition: << parameters.compress >>
       steps:

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -20,9 +20,10 @@ parameters:
       Accepted arguments vary with Unity's version and can be found in the docs: https://docs.unity3d.com/2021.2/Documentation/ScriptReference/BuildTarget.html
   build-name:
     type: string
-    default: "UnityBuild"
+    default: ""
     description: |
       Enter the name for this build.
+      If left blank, the build will be named after the target platform.
   cache-version:
     type: string
     default: "v1"

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -46,9 +46,10 @@ parameters:
       Accepted arguments vary with Unity's version and can be found in the docs: https://docs.unity3d.com/2022.2/Documentation/ScriptReference/BuildTarget.html
   build-name:
     type: string
-    default: "UnityBuild"
+    default: ""
     description: |
       Enter the name for this build.
+      If left blank, the build will be named after the target platform.
   compress:
     type: boolean
     default: true

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -13,6 +13,9 @@ detect-os
 mkdir -p "$unity_project_full_path/Assets/Editor/"
 printf '%s\n' "$DEPENDENCY_UNITY_BUILDER" > "$unity_project_full_path/Assets/Editor/BuildCommand.cs"
 
+# If "build_name" is blank, use the build target.
+if [ -z "$PARAM_BUILD_NAME" ]; then PARAM_BUILD_NAME="$PARAM_BUILD_TARGET"; fi
+
 if [ "$PLATFORM" = "linux" ]; then eval "$SCRIPT_BUILD_LINUX";
 elif [ "$PLATFORM" = "macos" ]; then eval "$SCRIPT_BUILD_MACOS";
 elif [ "$PLATFORM" = "windows" ]; then eval "$SCRIPT_BUILD_WINDOWS";

--- a/src/scripts/linux/build.sh
+++ b/src/scripts/linux/build.sh
@@ -18,7 +18,7 @@ trap_build_script_exit() {
     printf '%s\n' 'Compressing build artifacts...'
 
     # Compress artifacts to store them in the artifacts bucket.
-    tar -czf "$base_dir/$PARAM_BUILD_NAME-$PARAM_BUILD_TARGET.tar.gz" -C "$unity_project_full_path/Builds/$PARAM_BUILD_TARGET" .
+    tar -czf "$base_dir/$PARAM_BUILD_TARGET.tar.gz" -C "$unity_project_full_path/Builds/$PARAM_BUILD_TARGET" .
   fi
 }
 

--- a/src/scripts/linux/prepare-env.sh
+++ b/src/scripts/linux/prepare-env.sh
@@ -36,6 +36,7 @@ resolve_unity_license() {
       printf '%s\n' "Failed to generate Unity license file."
       printf '%s\n' "Make sure you have entered the correct username, password and serial and try again."
       printf '%s\n' "If you are still having problems, please open an issue."
+      printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation#professional-license"
 
       return 1
     fi
@@ -43,6 +44,7 @@ resolve_unity_license() {
   else
     printf '%s\n' "If you own a Personal Unity License File (.ulf), please provide it as a base64 encoded string."  
     printf '%s\n' "If you own a Plus or Pro Unity license, please provide your username, password and serial."
+    printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation"
 
     if create_manual_activation_file; then
       printf '%s\n' "Should you require a new Personal Activation License File (.alf), rerun the job with SSH and you will find it at \"${base_dir}/$(ls Unity_v*)\""

--- a/src/scripts/macos/build.sh
+++ b/src/scripts/macos/build.sh
@@ -25,5 +25,5 @@ if [ "$PARAM_COMPRESS" -eq 1 ]; then
   printf '%s\n' 'Compressing build artifacts...'
 
   # Compress artifacts to store them in the artifacts bucket.
-  tar -czf "$base_dir/$PARAM_BUILD_NAME-$PARAM_BUILD_TARGET.tar.gz" -C "$build_path" .
+  tar -czf "$base_dir/$PARAM_BUILD_TARGET.tar.gz" -C "$build_path" .
 fi

--- a/src/scripts/macos/prepare-env.sh
+++ b/src/scripts/macos/prepare-env.sh
@@ -78,6 +78,7 @@ resolve_unity_serial() {
       if ! extract_serial_from_license; then
         printf '%s\n' "Failed to parse the serial from the Unity license."
         printf '%s\n' "Please try again or open an issue."
+        printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation#personal-license"
         return 1
       
       else
@@ -88,6 +89,7 @@ resolve_unity_serial() {
     else
       printf '%s\n' "No serial or encoded license found."
       printf '%s\n' "Please run the script again with a serial or encoded license file."
+      printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation"
       return 1
     fi
   fi

--- a/src/scripts/windows/build.sh
+++ b/src/scripts/windows/build.sh
@@ -32,4 +32,4 @@ docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*
 docker exec "$CONTAINER_NAME" powershell 'tar -czf "C:/$Env:BUILD_NAME-$Env:BUILD_TARGET.tar.gz" -C "C:/build" .'
 
 # Copy the build directory to the host.
-docker cp "$CONTAINER_NAME":"$PARAM_BUILD_NAME"-"$PARAM_BUILD_TARGET".tar.gz "$base_dir"/"$PARAM_BUILD_NAME"-"$PARAM_BUILD_TARGET".tar.gz
+docker cp "$CONTAINER_NAME":"$PARAM_BUILD_NAME"-"$PARAM_BUILD_TARGET".tar.gz "$base_dir"/"$PARAM_BUILD_TARGET".tar.gz

--- a/src/scripts/windows/prepare-env.sh
+++ b/src/scripts/windows/prepare-env.sh
@@ -32,6 +32,8 @@ resolve_unity_serial() {
       if ! extract_serial_from_license; then
         printf '%s\n' "Failed to parse the serial from the Unity license."
         printf '%s\n' "Please try again or open an issue."
+        printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation#personal-license"
+
         exit_code=1
       
       else
@@ -42,6 +44,8 @@ resolve_unity_serial() {
     else
       printf '%s\n' "No serial or encoded license found."
       printf '%s\n' "Please run the script again with a serial or encoded license file."
+      printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation"
+
       exit_code=1
     fi
   fi

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -30,7 +30,8 @@ docker exec "$CONTAINER_NAME" powershell 'Invoke-WebRequest -Uri "https://versaw
 docker exec "$CONTAINER_NAME" powershell "Expand-Archive -Force C:/saxonb.zip C:/saxonb"
 
 # Copy the Saxon-B template to the container.
-docker cp "$gameci_sample_project_dir"/ci/nunit-transforms/nunit3-junit.xslt "$CONTAINER_NAME":C:/nunit3-junit.xslt
+printf '%s\n' "$DEPENDENCY_NUNIT_TRANSFORM" > "$base_dir/nunit3-junit.xslt"
+docker cp "$base_dir"/nunit3-junit.xslt "$CONTAINER_NAME":C:/nunit3-junit.xslt
 
 # Parse Unity's results xml to JUnit format.
 docker exec "$CONTAINER_NAME" powershell 'java -jar C:/saxonb/saxon9.jar -s C:/results.xml -xsl C:/nunit3-junit.xslt > C:/$Env:TEST_PLATFORM-junit-results.xml'


### PR DESCRIPTION
# Changes

- Change the `build-name` parameter to accept blank arguments.
- Add documentation links in several error messages.
- Fix the JUnit parsing issue in the Windows executor `test` job.