### PR TITLE
Add parameter return-license in build job

### DIFF
--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -68,6 +68,7 @@ parameters:
     default: true
     description: |
       Whether to return the license used to build or test the project.
+      Unity only allows returning professional licenses.
 
 executor: << parameters.executor >>
 

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -87,7 +87,9 @@ steps:
       project-path: <<parameters.project-path>>
       store-artifacts: <<parameters.store-artifacts>>
       compress: <<parameters.compress>>
-  - return-license:
-      unity-username-var-name: << parameters.unity-username-var-name >>
-      unity-password-var-name: << parameters.unity-password-var-name >>
-      when: <<parameters.return-license>>
+  - when:
+      condition: <<parameters.return-license>>
+      steps:
+        - return-license:
+            unity-username-var-name: << parameters.unity-username-var-name >>
+            unity-password-var-name: << parameters.unity-password-var-name >>

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -63,6 +63,11 @@ parameters:
       Whether to compress the build output to a ".tar.gz" archive.
       This is recommended if you want to download the built artifacts from the CircleCI web app.
       If left to "false" for decompressed WebGL builds, you can run the project directly from the CircleCI web app.
+  return-license:
+    type: boolean
+    default: true
+    description: |
+      Whether to return the license used to build or test the project.
 
 executor: << parameters.executor >>
 
@@ -84,3 +89,4 @@ steps:
   - return-license:
       unity-username-var-name: << parameters.unity-username-var-name >>
       unity-password-var-name: << parameters.unity-password-var-name >>
+      when: <<parameters.return-license>>

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -65,9 +65,9 @@ parameters:
       If left to "false" for decompressed WebGL builds, you can run the project directly from the CircleCI web app.
   return-license:
     type: boolean
-    default: true
+    default: false
     description: |
-      Whether to return the license used to build or test the project.
+      Whether to return the license used to build the project.
       Unity only allows returning professional licenses.
 
 executor: << parameters.executor >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -46,6 +46,12 @@ parameters:
       Specify the test platform to run tests on.
       Valid values are "editmode", "playmode" and Unity's target builds.
       More information can be found on: https://docs.unity3d.com/Packages/com.unity.test-framework@2.0/manual/reference-command-line.html
+  return-license:
+    type: boolean
+    default: false
+    description: |
+      Whether to return the license used to test the project.
+      Unity only allows returning professional licenses.
 
 executor: << parameters.executor >>
 
@@ -61,6 +67,9 @@ steps:
       step-name: << parameters.step-name >>
       test-platform: << parameters.test-platform >>
       project-path: << parameters.project-path >>
-  - return-license:
-      unity-username-var-name: << parameters.unity-username-var-name >>
-      unity-password-var-name: << parameters.unity-password-var-name >>
+  - when:
+      condition: <<parameters.return-license>>
+      steps:
+        - return-license:
+            unity-username-var-name: << parameters.unity-username-var-name >>
+            unity-password-var-name: << parameters.unity-password-var-name >>


### PR DESCRIPTION
https://game.ci/docs/github/returning-a-license

Since Unity only allows returning professional licenses, I added a parameter to switch whether returning licenses or not for other types of licenses.