### PR TITLE
feat: add `no_output_timeout` to commands and jobs

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -47,10 +47,15 @@ parameters:
       Whether to compress the build output to a ".tar.gz" archive.
       This is recommended if you want to download the built artifacts from the CircleCI web app.
       If left to "false" for decompressed WebGL builds, you can run the project directly from the CircleCI web app.
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: Elapsed time the command can run without output.
 
 steps:
   - run:
       name: << parameters.step-name >>
+      no_output_timeout: << parameters.no_output_timeout >>
       environment:
         PARAM_BUILD_NAME: << parameters.build-name >>
         PARAM_BUILD_TARGET: << parameters.build-target >>

--- a/src/commands/prepare-env.yml
+++ b/src/commands/prepare-env.yml
@@ -40,6 +40,10 @@ parameters:
     description: |
       Enter the path of your Unity project.
       This should be the directory that has an "Assets" folder inside it.
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: Elapsed time the command can run without output.
 
 steps:
   - restore_cache:
@@ -48,6 +52,7 @@ steps:
         - unity-deps-{{ arch }}-<< parameters.cache-version >>-<<# parameters.include-branch-in-cache-key >>{{ .Branch }}<</ parameters.include-branch-in-cache-key >>
   - run:
       name: Prepare the environment
+      no_output_timeout: << parameters.no_output_timeout >>
       environment:
         PARAM_UNITY_USERNAME_VAR_NAME: << parameters.unity-username-var-name >>
         PARAM_UNITY_PASSWORD_VAR_NAME: << parameters.unity-password-var-name >>

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -30,10 +30,15 @@ parameters:
       default: true
       description: >
           If true, this cache bucket will only apply to jobs within the same branch.
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: Elapsed time the command can run without output.
 
 steps:
   - run:
       name: << parameters.step-name >>
+      no_output_timeout: << parameters.no_output_timeout >>
       environment:
         PARAM_PROJECT_PATH: << parameters.project-path >>
         PARAM_TEST_PLATFORM: << parameters.test-platform >>

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -69,6 +69,10 @@ parameters:
     description: |
       Whether to return the license used to build the project.
       Unity only allows returning professional licenses.
+  no_output_timeout:
+    type: string
+    default: "20m"
+    description: Elapsed time the command can run without output.
 
 executor: << parameters.executor >>
 
@@ -80,6 +84,7 @@ steps:
       unity-serial-var-name: << parameters.unity-serial-var-name >>
       unity-license-var-name: << parameters.unity-license-var-name >>
       project-path: <<parameters.project-path>>
+      no_output_timeout: << parameters.no_output_timeout>>
   - build:
       step-name: << parameters.step-name >>
       build-name: <<parameters.build-name>>
@@ -87,6 +92,7 @@ steps:
       project-path: <<parameters.project-path>>
       store-artifacts: <<parameters.store-artifacts>>
       compress: <<parameters.compress>>
+      no_output_timeout: << parameters.no_output_timeout>>
   - when:
       condition: <<parameters.return-license>>
       steps:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -52,6 +52,10 @@ parameters:
     description: |
       Whether to return the license used to test the project.
       Unity only allows returning professional licenses.
+  no_output_timeout:
+    type: string
+    default: "20m"
+    description: Elapsed time the command can run without output.
 
 executor: << parameters.executor >>
 
@@ -63,10 +67,12 @@ steps:
       unity-serial-var-name: << parameters.unity-serial-var-name >>
       unity-license-var-name: << parameters.unity-license-var-name >>
       project-path: <<parameters.project-path>>
+      no_output_timeout: << parameters.no_output_timeout>>
   - test:
       step-name: << parameters.step-name >>
       test-platform: << parameters.test-platform >>
       project-path: << parameters.project-path >>
+      no_output_timeout: << parameters.no_output_timeout>>
   - when:
       condition: <<parameters.return-license>>
       steps:


### PR DESCRIPTION
## Changes

- Add a new `no_output_timeout` parameter to the `build` and `test` jobs.
- Add the same parameters to the `prepare-env`, `build` and `test` commands.

## Motivation

Closes #30 