### PR TITLE
fix: throw errors from the Unity CLI in the Windows `build` command

### DIFF
--- a/src/scripts/windows/build.sh
+++ b/src/scripts/windows/build.sh
@@ -1,6 +1,6 @@
 #!/bin/false
 # shellcheck shell=bash
-# shellcheck disable=SC2154
+# shellcheck disable=SC2016,SC2154
 
 trap_exit() {
   local exit_status="$?"
@@ -25,12 +25,33 @@ docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVa
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('BUILD_METHOD','$build_method', [System.EnvironmentVariableTarget]::Machine)"
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('CUSTOM_PARAMS','$custom_parameters', [System.EnvironmentVariableTarget]::Machine)"
 
+build_args=(
+  '-batchmode'
+  '-quit'
+  '-nographics'
+  '-projectPath $Env:PROJECT_PATH'
+  '-buildTarget $Env:BUILD_TARGET'
+  '-customBuildTarget $Env:BUILD_TARGET'
+  '-customBuildName $Env:BUILD_NAME'
+  '-customBuildPath "C:/build/"'
+  '-executeMethod $Env:BUILD_METHOD'
+)
+
+[ -n "$custom_parameters" ] && build_args+=( '$Env:CUSTOM_PARAMS.split()' )
+
 # Build the project
 # Versioning of the project needs work. This is how it's done in the GHA:
 # https://github.com/game-ci/unity-builder/blob/main/src/model/versioning.ts
 set -x
-docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -batchmode -quit -nographics -projectPath $Env:PROJECT_PATH -buildTarget $Env:BUILD_TARGET -customBuildTarget $Env:BUILD_TARGET -customBuildName $Env:BUILD_NAME -customBuildPath "C:/build/" -executeMethod $Env:BUILD_METHOD $Env:CUSTOM_PARAMS.split() -logfile | Out-Host'
+docker exec "$CONTAINER_NAME" powershell "& 'C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe' ${build_args[*]} -logfile | Out-Host"
+exit_code="$?"
 set +x
+
+if [ "$exit_code" -ne 0 ]; then
+  printf '%s\n' "Failed to build the project."
+  printf '%s\n' "Please try again, open an issue or reach out to us on Discord."
+  exit "$exit_code"
+fi
 
 # Compress the build folder.
 docker exec "$CONTAINER_NAME" powershell 'tar -czf "C:/$Env:BUILD_NAME-$Env:BUILD_TARGET.tar.gz" -C "C:/build" .'


### PR DESCRIPTION
## Motivation

Closes #33

## Changes

Capture the CLI's exit code and throws it in case of error. This PR also includes minor refactoring to make optional parameters easier to read and pass as arguments to the CLI.