### PR TITLE
chore: hard code links in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@
 
 <!-- please check all items and add your own -->
 
-- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
+- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
 - [ ] Documentation (updated or not needed)
 - [ ] Tests (added, updated or not needed)


### PR DESCRIPTION
#### Changes

- Replace relative links with their full path equivalent

Relative links do not work in pull requests. Support was requested [here](https://github.com/github/markup/issues/576), but the feature was never implemented. More information can be found [here](https://stackoverflow.com/questions/49242645/github-relative-internal-repository-links-in-pull-request-template-md).

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Documentation (updated or not needed)
- [x] Tests (added, updated or not needed)