### PR TITLE
feat: replace `docker cp` with a mounted volume in `build`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@
 
 <!-- please check all items and add your own -->
 
-- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
+- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
 - [ ] Documentation (updated or not needed)
 - [ ] Tests (added, updated or not needed)

--- a/src/scripts/windows/build.sh
+++ b/src/scripts/windows/build.sh
@@ -16,9 +16,6 @@ trap_exit() {
 }
 trap trap_exit EXIT
 
-# Create the build folder
-docker exec "$CONTAINER_NAME" powershell mkdir C:/build
-
 # Add the build target and build name in the environment variables.
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('BUILD_NAME','$PARAM_BUILD_NAME', [System.EnvironmentVariableTarget]::Machine)"
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('BUILD_TARGET','$PARAM_BUILD_TARGET', [System.EnvironmentVariableTarget]::Machine)"
@@ -53,8 +50,12 @@ if [ "$exit_code" -ne 0 ]; then
   exit "$exit_code"
 fi
 
-# Compress the build folder.
-docker exec "$CONTAINER_NAME" powershell 'tar -czf "C:/$Env:BUILD_NAME-$Env:BUILD_TARGET.tar.gz" -C "C:/build" .'
+printf '%s\n' "Build completed successfully. Here is your build's content:"
+ls -la "$base_dir/build"
 
-# Copy the build directory to the host.
-docker cp "$CONTAINER_NAME":"$PARAM_BUILD_NAME"-"$PARAM_BUILD_TARGET".tar.gz "$base_dir"/"$PARAM_BUILD_TARGET".tar.gz
+if [ "$PARAM_COMPRESS" -eq 1 ]; then
+  printf '%s\n' "Compressing artifacts..."
+  tar -vczf "$base_dir/${PARAM_BUILD_TARGET}.tar.gz" -C "$base_dir/build" .
+  printf '%s\n' "Done."
+  ls -la "$base_dir"
+fi

--- a/src/scripts/windows/build.sh
+++ b/src/scripts/windows/build.sh
@@ -50,12 +50,12 @@ if [ "$exit_code" -ne 0 ]; then
   exit "$exit_code"
 fi
 
-printf '%s\n' "Build completed successfully. Here is your build's content:"
+printf '%s\n' "Build completed successfully:"
 ls -la "$base_dir/build"
 
 if [ "$PARAM_COMPRESS" -eq 1 ]; then
   printf '%s\n' "Compressing artifacts..."
-  tar -vczf "$base_dir/${PARAM_BUILD_TARGET}.tar.gz" -C "$base_dir/build" .
+  tar -czf "$base_dir/${PARAM_BUILD_TARGET}.tar.gz" -C "$base_dir/build" .
   printf '%s\n' "Done."
   ls -la "$base_dir"
 fi

--- a/src/scripts/windows/prepare-env.sh
+++ b/src/scripts/windows/prepare-env.sh
@@ -94,7 +94,7 @@ if ! resolve_unity_serial; then
 fi
 
 # Create folder to store the build artifacts.
-mkdir -p "$base_dir/build"
+mkdir -p "$base_dir/build" || { echo "Unable to create the build directory"; exit 1; }
 
 set -x
 

--- a/src/scripts/windows/prepare-env.sh
+++ b/src/scripts/windows/prepare-env.sh
@@ -93,6 +93,9 @@ if ! resolve_unity_serial; then
   exit 1
 fi
 
+# Create folder to store the build artifacts.
+mkdir -p "$base_dir/build"
+
 set -x
 
 # Run the container and prevent it from exiting.
@@ -105,6 +108,7 @@ docker run -dit \
   --env UNITY_SERIAL="$resolved_unity_serial" \
   --volume "$unity_project_full_path":C:/unity_project \
   --volume "$base_dir"/regkeys:"C:/regkeys" \
+  --volume "$base_dir"/build:"C:/build" \
   --volume "C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \
   --volume "C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \
   --volume "C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \


### PR DESCRIPTION
#### Changes

This PR adds support for Windows Hyper-V containers by replacing `docker cp` with a mounted volume. At the moment, if a user runs the `build` command on a Hyper-V container, they will receive the following message:

> Error response from daemon: filesystem operations against a running Hyper-V container are not supported

With this change, a `build` folder is created inside the working directory and mounted in the Windows container. While this solves the issue above, it may result in leftover artifacts in non-ephemeral environments if the runner agent is not set to clean up the working directory. Alternatively, users can clean the directory themselves before the end of the workflow.


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Documentation (updated or not needed)
- [x] Tests (added, updated or not needed)