### PR TITLE
feat: replace `docker cp` with a mounted volume in `test`

### DIFF
--- a/src/scripts/windows/prepare-env.sh
+++ b/src/scripts/windows/prepare-env.sh
@@ -93,8 +93,9 @@ if ! resolve_unity_serial; then
   exit 1
 fi
 
-# Create folder to store the build artifacts.
-mkdir -p "$base_dir/build" || { echo "Unable to create the build directory"; exit 1; }
+# Create folders to store artifacts.
+mkdir -p "$base_dir/build" || { printf '%s\n' "Unable to create the build directory"; exit 1; }
+mkdir -p "$base_dir/test" || { printf '%s\n' "Unable to create the test directory"; exit 1; }
 
 set -x
 
@@ -109,6 +110,7 @@ docker run -dit \
   --volume "$unity_project_full_path":C:/unity_project \
   --volume "$base_dir"/regkeys:"C:/regkeys" \
   --volume "$base_dir"/build:"C:/build" \
+  --volume "$base_dir"/test:"C:/test" \
   --volume "C:/Program Files (x86)/Microsoft Visual Studio":"C:/Program Files (x86)/Microsoft Visual Studio" \
   --volume "C:/Program Files (x86)/Windows Kits":"C:/Program Files (x86)/Windows Kits" \
   --volume "C:/ProgramData/Microsoft/VisualStudio":"C:/ProgramData/Microsoft/VisualStudio" \

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -20,25 +20,24 @@ trap trap_exit EXIT
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('TEST_PLATFORM','$PARAM_TEST_PLATFORM', [System.EnvironmentVariableTarget]::Machine)"
 
 # Run the tests.
-docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -batchmode -nographics -projectPath $Env:PROJECT_PATH -runTests -testPlatform $Env:TEST_PLATFORM -testResults "C:/results.xml" -logfile | Out-Host'
+docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -batchmode -nographics -projectPath $Env:PROJECT_PATH -runTests -testPlatform $Env:TEST_PLATFORM -testResults "C:/test/results.xml" -logfile | Out-Host'
 
 # Install JDK to run Saxon.
 docker exec "$CONTAINER_NAME" powershell 'choco upgrade jdk8 --no-progress -y'
 
 # Download and extract Saxon-B.
-docker exec "$CONTAINER_NAME" powershell 'Invoke-WebRequest -Uri "https://versaweb.dl.sourceforge.net/project/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip" -Method "GET" -OutFile "C:/saxonb.zip"'
-docker exec "$CONTAINER_NAME" powershell "Expand-Archive -Force C:/saxonb.zip C:/saxonb"
+docker exec "$CONTAINER_NAME" powershell 'Invoke-WebRequest -Uri "https://versaweb.dl.sourceforge.net/project/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip" -Method "GET" -OutFile "C:/test/saxonb.zip"'
+docker exec "$CONTAINER_NAME" powershell "Expand-Archive -Force C:/test/saxonb.zip C:/test/saxonb"
 
 # Copy the Saxon-B template to the container.
-printf '%s\n' "$DEPENDENCY_NUNIT_TRANSFORM" > "$base_dir/nunit3-junit.xslt"
-docker cp "$base_dir"/nunit3-junit.xslt "$CONTAINER_NAME":C:/nunit3-junit.xslt
+printf '%s\n' "$DEPENDENCY_NUNIT_TRANSFORM" > "$base_dir/test/nunit3-junit.xslt"
 
 # Parse Unity's results xml to JUnit format.
-docker exec "$CONTAINER_NAME" powershell 'java -jar C:/saxonb/saxon9.jar -s C:/results.xml -xsl C:/nunit3-junit.xslt > C:/$Env:TEST_PLATFORM-junit-results.xml'
+docker exec "$CONTAINER_NAME" powershell 'java -jar C:/test/saxonb/saxon9.jar -s C:/test/results.xml -xsl C:/test/nunit3-junit.xslt > C:/test/junit-results.xml'
 
 # Convert CRLF to LF otherwise CircleCI won't be able to read the results.
 # https://stackoverflow.com/a/48919146
-docker exec "$CONTAINER_NAME" powershell '((Get-Content C:/playmode-junit-results.xml) -join "`n") + "`n" | Set-Content -NoNewline -Encoding utf8 C:/playmode-junit-results-lf.xml'
+docker exec "$CONTAINER_NAME" powershell '((Get-Content C:/test/junit-results.xml) -join "`n") + "`n" | Set-Content -NoNewline -Encoding utf8 C:/test/junit-results-lf.xml'
 
-# Copy test results to the host.
-docker cp "$CONTAINER_NAME":"$PARAM_TEST_PLATFORM"-junit-results-lf.xml "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-junit-results.xml
+# Move test results to project folder for upload.
+mv "$base_dir"/test/junit-results-lf.xml "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-junit-results.xml


### PR DESCRIPTION
#### Changes

- In a similar fashion to #47, this change replaces `docker cp` with a mounted volume to support Hyper-V containers.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Documentation (updated or not needed)
- [x] Tests (added, updated or not needed)