### PR TITLE
feat: add a `custom-parameters` parameter in the `test` job and command.

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -129,7 +129,7 @@ workflows:
             editor_version: "2021.3.2f1"
             target_platform: "windows-il2cpp"
           project-path: "Unity2D-Demo-Game-CI-CD/src"
-          custom-parameters: "-testFilter EnemyMovesLeft"
+          custom-parameters: "-testFilter EnemyMovesLeft -customParam1 potato -customParam2 $CIRCLE_WORKFLOW_ID"
           test-platform: "playmode"
           filters: *filters
           context: orb-testing-unity
@@ -160,7 +160,7 @@ workflows:
             editor_version: "2021.3.1f1"
             resource_class: "large"
           project-path: "Unity2D-Demo-Game-CI-CD/src"
-          custom-parameters: "-testFilter EnemyMovesLeft"
+          custom-parameters: "-testFilter EnemyMovesLeft -customParam1 potato -customParam2 $CIRCLE_WORKFLOW_ID"
           test-platform: "playmode"
           filters: *filters
           context: orb-testing-unity

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -118,7 +118,7 @@ workflows:
           context: orb-testing-unity
           pre-steps: *mono
       - unity/test:
-          name: "test-windows"
+          name: "test-windows-with-custom-parameters"
           step-name: "Check if test filter in custom parameter works"
           unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
           unity-username-var-name: "UNITY_USERNAME"
@@ -150,7 +150,7 @@ workflows:
           context: orb-testing-unity
           pre-steps: *mono
       - unity/test:
-          name: "test-osx"
+          name: "test-osx-with-custom-parameters"
           step-name: "Check if test filter in custom parameter works"
           unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
           unity-username-var-name: "UNITY_USERNAME"
@@ -462,7 +462,9 @@ workflows:
             - orb-tools/pack
             - test-linux
             - test-windows
+            - test-windows-with-custom-parameters
             - test-osx
+            - test-osx-with-custom-parameters
             - build-linux64-il2cpp
             - build-Windows64-il2cpp
             - build-osx-il2cpp

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,6 +102,23 @@ workflows:
           context: orb-testing-unity
           pre-steps: *mono
       - unity/test:
+          name: "test-linux-with-custom-parameters"
+          step-name: "Check if test filter in custom parameter works"
+          unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
+          unity-username-var-name: "UNITY_USERNAME"
+          unity-password-var-name: "UNITY_PASSWORD"
+          executor:
+            name: "unity/ubuntu"
+            target_platform: "linux-il2cpp"
+            editor_version: "2021.3.1f1"
+            resource_class: "medium"
+          project-path: "Unity2D-Demo-Game-CI-CD/src"
+          custom-parameters: "-testFilter EnemyMovesLeft -customParam1 potato -customParam2 $CIRCLE_WORKFLOW_ID"
+          test-platform: "playmode"
+          filters: *filters
+          context: orb-testing-unity
+          pre-steps: *mono
+      - unity/test:
           name: "test-windows"
           step-name: "Check if the tests run and results are uploaded"
           unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
@@ -461,6 +478,7 @@ workflows:
           requires:
             - orb-tools/pack
             - test-linux
+            - test-linux-with-custom-parameters
             - test-windows
             - test-windows-with-custom-parameters
             - test-osx

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -118,6 +118,23 @@ workflows:
           context: orb-testing-unity
           pre-steps: *mono
       - unity/test:
+          name: "test-windows"
+          step-name: "Check if test filter in custom parameter works"
+          unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
+          unity-username-var-name: "UNITY_USERNAME"
+          unity-password-var-name: "UNITY_PASSWORD"
+          executor:
+            name: "unity/windows-2019"
+            size: "large"
+            editor_version: "2021.3.2f1"
+            target_platform: "windows-il2cpp"
+          project-path: "Unity2D-Demo-Game-CI-CD/src"
+          custom-parameters: "-testFilter EnemyMovesLeft"
+          test-platform: "playmode"
+          filters: *filters
+          context: orb-testing-unity
+          pre-steps: *mono
+      - unity/test:
           name: "test-osx"
           step-name: "Check if the tests run and results are uploaded"
           unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
@@ -128,6 +145,22 @@ workflows:
             editor_version: "2021.3.1f1"
             resource_class: "large"
           project-path: "Unity2D-Demo-Game-CI-CD/src"
+          test-platform: "playmode"
+          filters: *filters
+          context: orb-testing-unity
+          pre-steps: *mono
+      - unity/test:
+          name: "test-osx"
+          step-name: "Check if test filter in custom parameter works"
+          unity-license-var-name: "UNITY_ENCODED_LICENSE_2021"
+          unity-username-var-name: "UNITY_USERNAME"
+          unity-password-var-name: "UNITY_PASSWORD"
+          executor:
+            name: "unity/macos"
+            editor_version: "2021.3.1f1"
+            resource_class: "large"
+          project-path: "Unity2D-Demo-Game-CI-CD/src"
+          custom-parameters: "-testFilter EnemyMovesLeft"
           test-platform: "playmode"
           filters: *filters
           context: orb-testing-unity

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -34,6 +34,14 @@ parameters:
     type: string
     default: "10m"
     description: Elapsed time the command can run without output.
+  custom-parameters:
+    type: string
+    default: ""
+    description: |
+      Additional arguments for the Unity CLI.
+      Use it to pass arguments to Unity's test options. Environment variables are supported.
+      The parameters must be separated by space and must be in the format "-key value" or "-key" for booleans.
+      Example: '-testFilter "MyNamespace.Something.MyTest" -assemblyNames "MyUnitTestAssembly" -testCategory "Unit;Integration"'.
 
 steps:
   - run:
@@ -42,6 +50,7 @@ steps:
       environment:
         PARAM_PROJECT_PATH: << parameters.project-path >>
         PARAM_TEST_PLATFORM: << parameters.test-platform >>
+        PARAM_CUSTOM_PARAMETERS: << parameters.custom-parameters >>
         SCRIPT_TEST_LINUX: << include(scripts/linux/test.sh) >>
         SCRIPT_TEST_WINDOWS: << include(scripts/windows/test.sh) >>
         SCRIPT_TEST_MACOS: << include(scripts/macos/test.sh) >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -56,6 +56,14 @@ parameters:
     type: string
     default: "20m"
     description: Elapsed time the command can run without output.
+  custom-parameters:
+    type: string
+    default: ""
+    description: |
+      Additional arguments for the Unity CLI.
+      Use it to pass arguments to Unity's test options. Environment variables are supported.
+      The parameters must be separated by space and must be in the format "-key value" or "-key" for booleans.
+      Example: '-testFilter "MyNamespace.Something.MyTest" -assemblyNames "MyUnitTestAssembly" -testCategory "Unit;Integration"'.
 
 executor: << parameters.executor >>
 
@@ -73,6 +81,7 @@ steps:
       test-platform: << parameters.test-platform >>
       project-path: << parameters.project-path >>
       no_output_timeout: << parameters.no_output_timeout>>
+      custom-parameters: << parameters.custom-parameters >>
   - when:
       condition: <<parameters.return-license>>
       steps:

--- a/src/scripts/linux/test.sh
+++ b/src/scripts/linux/test.sh
@@ -8,7 +8,7 @@ parse_results_to_junit() {
 
   # Parse Unity's results xml to JUnit format.
   printf '%s\n' "$DEPENDENCY_NUNIT_TRANSFORM" >"$base_dir/nunit3-junit.xslt"
-  saxonb-xslt -s "$UNITY_DIR/$TEST_PLATFORM-results.xml" -xsl "$base_dir/nunit3-junit.xslt" >"$UNITY_DIR/$TEST_PLATFORM-junit-results.xml"
+  saxonb-xslt -s "$unity_project_full_path/$PARAM_TEST_PLATFORM-results.xml" -xsl "$base_dir/nunit3-junit.xslt" >"$unity_project_full_path/$PARAM_TEST_PLATFORM-junit-results.xml"
 }
 
 set -x

--- a/src/scripts/linux/test.sh
+++ b/src/scripts/linux/test.sh
@@ -43,7 +43,7 @@ package_manifest_path="$unity_project_full_path/Packages/manifest.json"
 
 # Check if the Code Coverage package is installed and move the coverage results to the root of the project.
 if grep -q "$code_coverage_package" "$package_manifest_path"; then
-  cat "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-coverage/Report/Summary.xml | grep Linecoverage
+  grep "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-coverage/Report/Summary.xml Linecoverage
   mv "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-coverage/"$CIRCLE_PROJECT_REPONAME"-opencov/*Mode/TestCoverageResults_*.xml "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-coverage/coverage.xml
   rm -r "$unity_project_full_path"/"$PARAM_TEST_PLATFORM"-coverage/"$CIRCLE_PROJECT_REPONAME"-opencov/
 else

--- a/src/scripts/macos/test.sh
+++ b/src/scripts/macos/test.sh
@@ -71,6 +71,7 @@ parse_xml_to_junit() {
 
 set -x
 # Run the tests.
+# shellcheck disable=SC2086 # $custom_parameters needs to be unquoted. Otherwise it will be treated as a single parameter.
 "$UNITY_EDITOR_PATH" \
   -batchmode \
   -nographics \
@@ -79,7 +80,7 @@ set -x
   -testPlatform "$PARAM_TEST_PLATFORM" \
   -testResults "$base_dir/results.xml" \
   -logfile /dev/stdout \
-  $custom_parameters # Needs to be unquoted. Otherwise it will be treated as a single parameter.
+  $custom_parameters
 
 unity_exit_code=$?
 set +x

--- a/src/scripts/macos/test.sh
+++ b/src/scripts/macos/test.sh
@@ -78,7 +78,8 @@ set -x
   -runTests \
   -testPlatform "$PARAM_TEST_PLATFORM" \
   -testResults "$base_dir/results.xml" \
-  -logfile /dev/stdout
+  -logfile /dev/stdout \
+  $custom_parameters # Needs to be unquoted. Otherwise it will be treated as a single parameter.
 
 unity_exit_code=$?
 set +x

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -10,6 +10,9 @@ eval "$SCRIPT_UTILS"
 # Detect host OS.
 detect-os
 
+# Expand custom parameters, if any.
+custom_parameters="$(eval echo "$PARAM_CUSTOM_PARAMETERS")"
+
 if [ "$PLATFORM" = "linux" ]; then eval "$SCRIPT_TEST_LINUX";
 elif [ "$PLATFORM" = "macos" ]; then eval "$SCRIPT_TEST_MACOS";
 elif [ "$PLATFORM" = "windows" ]; then eval "$SCRIPT_TEST_WINDOWS";

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -11,7 +11,7 @@ eval "$SCRIPT_UTILS"
 detect-os
 
 # Expand custom parameters, if any.
-custom_parameters="$(eval echo "$PARAM_CUSTOM_PARAMETERS")"
+custom_parameters="$(eval echo "$PARAM_CUSTOM_PARAMETERS")" && readonly custom_parameters
 
 if [ "$PLATFORM" = "linux" ]; then eval "$SCRIPT_TEST_LINUX";
 elif [ "$PLATFORM" = "macos" ]; then eval "$SCRIPT_TEST_MACOS";

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -1,6 +1,6 @@
 #!/bin/false
 # shellcheck shell=bash
-# shellcheck disable=SC2154
+# shellcheck disable=SC2154,SC2016
 
 trap_exit() {
   local exit_status="$?"

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -26,7 +26,7 @@ test_args=(
   '-projectPath $Env:PROJECT_PATH'
   '-runTests'
   '-testPlatform $Env:TEST_PLATFORM'
-  '-testResults "C:/test/results.xml'
+  '-testResults "C:/test/results.xml"'
 )
 
 [ -n "$custom_parameters" ] && test_args+=( '$Env:CUSTOM_PARAMS.split()' )

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -16,11 +16,25 @@ trap_exit() {
 }
 trap trap_exit EXIT
 
-# Add the build target and build name in the environment variables.
+# Add necessary values in the environment variables.
 docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('TEST_PLATFORM','$PARAM_TEST_PLATFORM', [System.EnvironmentVariableTarget]::Machine)"
+docker exec "$CONTAINER_NAME" powershell "[System.Environment]::SetEnvironmentVariable('CUSTOM_PARAMS','$custom_parameters', [System.EnvironmentVariableTarget]::Machine)"
+
+test_args=(
+  '-batchmode'
+  '-nographics'
+  '-projectPath $Env:PROJECT_PATH'
+  '-runTests'
+  '-testPlatform $Env:TEST_PLATFORM'
+  '-testResults "C:/test/results.xml'
+)
+
+[ -n "$custom_parameters" ] && test_args+=( '$Env:CUSTOM_PARAMS.split()' )
 
 # Run the tests.
-docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -batchmode -nographics -projectPath $Env:PROJECT_PATH -runTests -testPlatform $Env:TEST_PLATFORM -testResults "C:/test/results.xml" -logfile | Out-Host'
+set -x
+docker exec "$CONTAINER_NAME" powershell "& 'C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe' ${test_args[*]} -logfile | Out-Host"
+set +x
 
 # Install JDK to run Saxon.
 docker exec "$CONTAINER_NAME" powershell 'choco upgrade jdk8 --no-progress -y'


### PR DESCRIPTION
#### Changes

Add a new `custom-parameters` parameter to the `test` job and command. This will increase flexibility around the flags and data that can be passed to the Unity CLI as an argument, closing #56.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
- [ ] Documentation (updated or not needed)
- [x] Tests (added, updated or not needed)