### PR TITLE
fix: Bump image version from 2 to 3 in Ubuntu

### DIFF
--- a/src/executors/ubuntu-container-runner.yml
+++ b/src/executors/ubuntu-container-runner.yml
@@ -24,7 +24,7 @@ parameters:
     type: string
 
 docker:
-  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-2'
+  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-3'
     environment:
       - GAMECI_EDITOR_VERSION=<< parameters.editor_version >>
       - GAMECI_TARGET_PLATFORM=<< parameters.target_platform >>

--- a/src/executors/ubuntu.yml
+++ b/src/executors/ubuntu.yml
@@ -26,7 +26,7 @@ parameters:
     enum: [ small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+ ]
 
 docker:
-  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-3.1.0'
+  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-3'
     environment:
       - GAMECI_EDITOR_VERSION=<< parameters.editor_version >>
       - GAMECI_TARGET_PLATFORM=<< parameters.target_platform >>

--- a/src/executors/ubuntu.yml
+++ b/src/executors/ubuntu.yml
@@ -26,7 +26,7 @@ parameters:
     enum: [ small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+ ]
 
 docker:
-  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-2'
+  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-<<parameters.target_platform>>-3.1.0'
     environment:
       - GAMECI_EDITOR_VERSION=<< parameters.editor_version >>
       - GAMECI_TARGET_PLATFORM=<< parameters.target_platform >>

--- a/src/jobs/create-activation-file.yml
+++ b/src/jobs/create-activation-file.yml
@@ -10,7 +10,7 @@ parameters:
     default: "2021.3.7f1"
 
 docker:
-  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-base-1'
+  - image: 'unityci/editor:ubuntu-<<parameters.editor_version>>-base-3'
 
 resource_class: medium
 


### PR DESCRIPTION
#### Changes

- Bump image version in the ubuntu

#### Checklist

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Documentation (updated or not needed)=not needed
- [x] Tests (added, updated or not needed)=not needed

#### Additional changes still need
The orb needs to clarify which image versions or Docker repo versions are supported in circle ci otherwise developers may stuck when getting this error in more latest versions of unity editor:
```
Starting container unityci/editor:ubuntu-2022.3.27f1-linux-il2cpp-2
Warning: No authentication provided, using CircleCI credentials for pulls from Docker Hub.
  image cache not found on this host, downloading unityci/editor:ubuntu-2022.3.*-linux-il2cpp-2

Error response from daemon: manifest for unityci/editor:ubuntu-2022.3.*-linux-il2cpp-2 not found: manifest unknown: manifest unknown
```
The issue is discussed more in details here #64 