### PR TITLE
Fix issue #73 "Unity Hub: Bad CPU type in executable"

### DIFF
--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -15,7 +15,7 @@ parameters:
       For details on resource class availability, see https://circleci.com/docs/using-macos#available-resource-classes.
     type: enum
     default: macos.m1.medium.gen1
-    enum: [ medium, macos.m1.medium.gen1, large, macos.m1.large.gen1 ]
+    enum: [ macos.m1.medium.gen1, macos.m1.large.gen1 ]
   xcode_version:
     description: |
       Pick the Xcode version.

--- a/src/scripts/macos/prepare-env.sh
+++ b/src/scripts/macos/prepare-env.sh
@@ -44,7 +44,7 @@ check_and_install_unity_editor() {
       changeset="$(npx unity-changeset "$UNITY_EDITOR_VERSION")"
 
       set -x
-      "$unity_hub_path" -- --headless install --version "$UNITY_EDITOR_VERSION" --changeset "$changeset" --module mac-il2cpp --childModules
+      arch -x86_64 "$unity_hub_path" -- --headless install --version "$UNITY_EDITOR_VERSION" --changeset "$changeset" --module mac-il2cpp --childModules
       set +x
 
       if [ -f "$unity_editor_path" ]; then
@@ -139,7 +139,7 @@ sudo chmod -R 777 "$unity_license_file_path"
 
 # Activate the Unity Editor.
 set -x
-"$unity_editor_path" \
+arch -x86_64 "$unity_editor_path" \
   -batchmode \
   -quit \
   -nographics \

--- a/src/scripts/macos/prepare-env.sh
+++ b/src/scripts/macos/prepare-env.sh
@@ -59,7 +59,7 @@ check_and_install_unity_editor() {
       changeset="$(npx unity-changeset "$UNITY_EDITOR_VERSION")"
 
       set -x
-      arch -x86_64 "$unity_hub_path" -- --headless install --version "$UNITY_EDITOR_VERSION" --changeset "$changeset" --module mac-il2cpp --childModules  -a arm64
+      arch -x86_64 "$unity_hub_path" -- --headless install --version "$UNITY_EDITOR_VERSION" --changeset "$changeset" --module mac-il2cpp --childModules -a arm64
       set +x
 
       if [ -f "$unity_editor_path" ]; then


### PR DESCRIPTION
#### Changes
- Updated enums to reflect depricated environments, the only supported environments for macos are non-intel based M1's.
- Fixed Bad CPU issue by using rosetta2 to run unity hub.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](/game-ci/unity-orb/blob/main/CONTRIBUTING.md) and accept the [code](/game-ci/unity-orb/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Documentation (updated or not needed)
- [x] Tests (added, updated or not needed)

Closes #73 