### PR TITLE
Fix shellcheck in macOS preparation script

### DIFF
--- a/src/scripts/macos/prepare-env.sh
+++ b/src/scripts/macos/prepare-env.sh
@@ -11,8 +11,7 @@ printf '%s\n' "export UNITY_EDITOR_PATH=$unity_editor_path" >> "$BASH_ENV"
 check_and_install_rosetta() {
   if ! /usr/bin/pgrep oahd &> /dev/null; then
     echo "Rosetta 2 is not installed. Installing it now..."
-    softwareupdate --install-rosetta --agree-to-license
-    if [ $? -eq 0 ]; then
+    if softwareupdate --install-rosetta --agree-to-license; then
       echo "Rosetta 2 installed successfully."
     else
       echo "Failed to install Rosetta 2."
@@ -89,13 +88,13 @@ resolve_unity_serial() {
     # License provided.
     elif [ -n "$unity_encoded_license" ]; then
       printf '%s\n' "No serial detected. Extracting it from the encoded license."
-      
+
       if ! extract_serial_from_license; then
         printf '%s\n' "Failed to parse the serial from the Unity license."
         printf '%s\n' "Please try again or open an issue."
         printf '%s\n' "See the docs for more details: https://game.ci/docs/circleci/activation#personal-license"
         return 1
-      
+
       else
         readonly resolved_unity_serial="$decoded_unity_serial"
       fi
@@ -116,7 +115,7 @@ extract_serial_from_license() {
   # Fix locale setting in PERL.
   # https://stackoverflow.com/a/7413863
   export LC_CTYPE=en_US.UTF-8
-  export LC_ALL=en_US.UTF-8 
+  export LC_ALL=en_US.UTF-8
 
   local unity_license
   local developer_data
@@ -125,7 +124,7 @@ extract_serial_from_license() {
   unity_license="$(base64 --decode <<< "$unity_encoded_license")"
   developer_data="$(perl -nle 'print $& while m{<DeveloperData Value\="\K.*?(?="/>)}g' <<< "$unity_license")"
   encoded_serial="$(cut -c 5- <<< "$developer_data")"
-  
+
   decoded_unity_serial="$(base64 --decode <<< "$encoded_serial")"
   readonly decoded_unity_serial
 


### PR DESCRIPTION
Replaced `if [ $? -eq 0 ]; then` with `if softwareupdate --install-rosetta --agree-to-license; then` in the `check_and_install_rosetta` function to check the exit status directly.

Other changes are basically white spaces handled by Jetbrains IntelliJ Idea in there

This is a followup PR on top of #76 

![CleanShot 2024-06-25 at 16 33 10@2x](https://github.com/game-ci/unity-orb/assets/1264761/1fe68d19-0d9a-4333-93a2-13e171b81f6c)
